### PR TITLE
Importing HTML templates as String

### DIFF
--- a/_templates/component/new/component.ejs.t
+++ b/_templates/component/new/component.ejs.t
@@ -3,7 +3,7 @@ to: src/app/<%=path%>/<%=name%>/<%=name%>.component.js
 ---
 'use strict';
 
-import template from './<%=name%>.html';
+import template from './<%=name%>.html?raw';
 import controller from './<%=name%>.controller';
 import './<%=name%>.scss';
 


### PR DESCRIPTION
I fixed the import to allow Vite to read the HTML file template as a string and avoid a runtime error after importing the new component.